### PR TITLE
Prefer openapi.yml to openapi.json

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 
 
-## Was the documentation (README, DevOpsDocs, wiki, openapi.json) updated?
+## Was the documentation (README, DevOpsDocs, wiki, openapi.yml) updated?
 
 
 


### PR DESCRIPTION
Connects to #42

## Why was this change made?

For consistency.

## Was the documentation (README, DevOpsDocs, wiki, openapi.yml) updated?

No.

## Does this change affect how this application integrates with other services?


No