### PR TITLE
Disable assets

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  # config.assets.compile = false
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 


### PR DESCRIPTION


## Why was this change made?

We don't have the asset gems loaded, so this configuration breaks the deployment. This is an API only app

## Was the documentation (README, DevOpsDocs, wiki, openapi.yml) updated?
no


## Does this change affect how this application integrates with other services?
no
If so, please confirm:
- change was tested on stage   and/or
- change was tested via integration test   and/or
- test added to sul-dlss/infrastructure-integration-test
