### PR TITLE
Enable new rubocop rules to avoid warning messages

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 117
 
 Metrics/BlockLength:
@@ -25,3 +25,12 @@ Style/MixinUsage:
 
 RSpec/MultipleExpectations:
   Max: 5
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true


### PR DESCRIPTION
## Why was this change made?
to avoid warning messages


## Was the documentation (README, DevOpsDocs, wiki, openapi.yml) updated?
no


## Does this change affect how this application integrates with other services?
no
If so, please confirm:
- change was tested on stage   and/or
- change was tested via integration test   and/or
- test added to sul-dlss/infrastructure-integration-test
