### PR TITLE
don't set PASSENGER_INSTANCE_REGISTRY_DIR for RPM passenger

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -42,7 +42,8 @@ append :linked_dirs, 'log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'public/syst
 # set :ssh_options, verify_host_key: :secure
 
 # capistrano/passenger wouldn't restart Passenger without this
-set :passenger_environment_variables, 'PASSENGER_INSTANCE_REGISTRY_DIR' => '/var/run'
+# not needed for RPM based passenger.
+# set :passenger_environment_variables, 'PASSENGER_INSTANCE_REGISTRY_DIR' => '/var/run'
 
 # update shared_configs before restarting app
 before 'deploy:restart', 'shared_configs:update'


### PR DESCRIPTION
## Why was this change made?

Passenger doesn't restart for systems using the RPM based Passenger if you set `PASSENGER_INSTANCE_REGISTRY_DIR`

## Was the documentation (README, DevOpsDocs, wiki, openapi.yml) updated?

no

## Does this change affect how this application integrates with other services?
no
If so, please confirm:
- change was tested on stage   and/or
- change was tested via integration test   and/or
- test added to sul-dlss/infrastructure-integration-test
