### PR TITLE
Update the Capfile lock

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # config valid for current version and patch releases of Capistrano
-lock '~> 3.12.1'
+lock '~> 3.13.0'
 
 set :application, 'suri'
 set :repo_url, 'https://github.com/sul-dlss/suri-rails.git'


### PR DESCRIPTION
## Why was this change made?
Set it to work with the installed version of Capistrano


## Was the documentation (README, DevOpsDocs, wiki, openapi.yml) updated?


no
## Does this change affect how this application integrates with other services?
no

If so, please confirm:
- change was tested on stage   and/or
- change was tested via integration test   and/or
- test added to sul-dlss/infrastructure-integration-test
