### PR TITLE
Add Honeybadger

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -32,6 +32,7 @@ require 'capistrano/rvm'
 require 'capistrano/bundler'
 require 'capistrano/rails/migrations'
 require 'capistrano/passenger'
+require 'capistrano/honeybadger'
 require 'dlss/capistrano'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'bootsnap' # Added in Rails 5.2 to speed up boot times
 gem 'committee'
+gem 'honeybadger'
 gem 'okcomputer'
 gem 'pg'
 gem 'puma', '~> 4.3' # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    honeybadger (4.6.0)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
@@ -257,6 +258,7 @@ DEPENDENCIES
   capistrano-rvm
   committee
   dlss-capistrano
+  honeybadger
   listen (>= 3.0.5, < 3.2)
   okcomputer
   pg

--- a/app/controllers/identifiers_controller.rb
+++ b/app/controllers/identifiers_controller.rb
@@ -13,6 +13,7 @@ class IdentifiersController < ApplicationController
     @identifier = Identifier.find_by!(identifier: params[:id])
     render json: @identifier
   rescue ActiveRecord::RecordNotFound
+    # NOTE: 404s are not Honeybadger-worthy
     render build_error("Identifier not found: #{params[:id]}", :not_found)
   end
 
@@ -23,7 +24,9 @@ class IdentifiersController < ApplicationController
     if @identifier
       render plain: @identifier.identifier, status: :created, location: @identifier
     else
-      render build_error('Unable to mint a druid', :internal_server_error)
+      error_message = 'Unable to mint a druid'
+      Honeybadger.notify(error_message)
+      render build_error(error_message, :internal_server_error)
     end
   end
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -38,6 +38,12 @@ append :linked_dirs, 'log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'public/syst
 # Default value for keep_releases is 5
 # set :keep_releases, 5
 
+# honeybadger_env otherwise defaults to rails_env
+set :honeybadger_env, fetch(:stage)
+# See https://github.com/honeybadger-io/honeybadger-ruby/issues/129 &
+# https://github.com/honeybadger-io/honeybadger-ruby/blob/7eea24a47d44aed663e315be970e501b7cf092fc/vendor/capistrano-honeybadger/README.md
+set :honeybadger_server, primary(:app)
+
 # Uncomment the following to require manually verifying the host key before first deploy.
 # set :ssh_options, verify_host_key: :secure
 

--- a/spec/requests/identifiers_spec.rb
+++ b/spec/requests/identifiers_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe 'Identifiers', type: :request do
     context 'with a broken minter' do
       before do
         allow(Identifier).to receive(:mint).and_return(nil)
+        allow(Honeybadger).to receive(:notify)
       end
 
       it 'renders an error' do
@@ -65,6 +66,7 @@ RSpec.describe 'Identifiers', type: :request do
           'title' => 'Unable to mint a druid',
           'detail' => 'Unable to mint a druid'
         )
+        expect(Honeybadger).to have_received(:notify).once
       end
     end
   end


### PR DESCRIPTION
Fixes #53

Includes Honeybadger dependency, Capistrano setup, and usage in identifiers controller.

## Why was this change made?

To report error alerts and record deployments.

## Was the documentation (README, DevOpsDocs, wiki, openapi.yml) updated?

No.

## Does this change affect how this application integrates with other services?

No.