### PR TITLE
Loosen the capistrano lock

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # config valid for current version and patch releases of Capistrano
-lock '~> 3.13.0'
+lock '~> 3.14'
 
 set :application, 'suri'
 set :repo_url, 'https://github.com/sul-dlss/suri-rails.git'


### PR DESCRIPTION
## Why was this change made?

The lock was set overly strictly, preventing deploy with capistrano 3.14.0

## Was the documentation (README, DevOpsDocs, wiki, openapi.yml) updated?

no

## Does this change affect how this application integrates with other services?
no