### PR TITLE
Return error information when minting identifiers

### DIFF
--- a/app/models/identifier.rb
+++ b/app/models/identifier.rb
@@ -5,22 +5,19 @@ require 'druid_minter'
 class Identifier < ApplicationRecord
   MAX_RETRIES = 10_000
 
-  # Create a new Identifier with a guaranteed-unique identifier field
-  #
-  # @return [Identifier]
-  # @return [false] if unable to mint an identifier after an appropriate amount of tries
+  # @param attributes [Hash] key/value pairs to pass into `Identifier#create!`
+  # @return [Identifier] return an identifier instance if no errors
+  # @raise [RuntimeError,ActiveRecord::ActiveRecordError] if minting encounters errors
   def self.mint(attributes = {})
-    catch(:id) do
-      MAX_RETRIES.times do
-        id = DruidMinter.generate
-        Identifier.transaction do
-          next if Identifier.where(identifier: id).any?
+    MAX_RETRIES.times do
+      id = DruidMinter.generate
+      Identifier.transaction do
+        next if Identifier.where(identifier: id).any?
 
-          throw :id, Identifier.create!(attributes.merge(identifier: id))
-        end
-
-        return false
+        return Identifier.create!(attributes.merge(identifier: id))
       end
     end
+
+    raise "Tried to mint a unique identifier #{MAX_RETRIES} times and failed."
   end
 end

--- a/spec/requests/identifiers_spec.rb
+++ b/spec/requests/identifiers_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe 'Identifiers', type: :request do
         expect(response).to have_http_status(:internal_server_error)
         expect(JSON.parse(response.body)['errors'].first).to include(
           'status' => '500',
-          'title' => 'Unable to mint a druid',
-          'detail' => 'Unable to mint a druid'
+          'title' => 'Unable to mint identifier',
+          'detail' => 'NoMethodError: undefined method `identifier\' for nil:NilClass'
         )
         expect(Honeybadger).to have_received(:notify).once
       end
@@ -98,8 +98,8 @@ RSpec.describe 'Identifiers', type: :request do
         expect(response).to have_http_status(:internal_server_error)
         expect(JSON.parse(response.body)['errors'].first).to include(
           'status' => '500',
-          'title' => 'Unable to mint a druid',
-          'detail' => 'Unable to mint a druid'
+          'title' => 'Unable to mint identifier',
+          'detail' => 'NoMethodError: undefined method `identifier\' for nil:NilClass'
         )
       end
     end


### PR DESCRIPTION
Fixes #64

## Why was this change made?

To help downstream API consumers figure out why minting failed.

## How was this change tested?

Unit tests. 

## Which documentation and/or configurations were updated?

None.

