### PR TITLE
[Migration - does not need merging] Tooling for migrating legacy oracle database

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,11 @@ gem 'pg'
 gem 'puma', '~> 4.3' # Use Puma as the app server
 gem 'rails', '~> 6.0.1'
 
+group :production do
+  gem 'ruby-oci8'
+  gem 'activerecord-oracle_enhanced-adapter'
+end
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,9 @@ gem 'puma', '~> 4.3' # Use Puma as the app server
 gem 'rails', '~> 6.0.1'
 
 group :production do
+  # we can remove this section after we've migrated the data 
   gem 'ruby-oci8'
+  gem 'activerecord-import'
   gem 'activerecord-oracle_enhanced-adapter'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,9 @@ GEM
     activerecord (6.0.3.1)
       activemodel (= 6.0.3.1)
       activesupport (= 6.0.3.1)
+    activerecord-oracle_enhanced-adapter (6.0.2)
+      activerecord (~> 6.0.0)
+      ruby-plsql (>= 0.6.0)
     activestorage (6.0.3.1)
       actionpack (= 6.0.3.1)
       activejob (= 6.0.3.1)
@@ -216,6 +219,8 @@ GEM
       rubocop (>= 0.72.0)
     rubocop-rspec (1.40.0)
       rubocop (>= 0.68.1)
+    ruby-oci8 (2.2.8)
+    ruby-plsql (0.7.1)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     simplecov (0.17.1)
@@ -251,6 +256,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-oracle_enhanced-adapter
   bootsnap
   byebug
   capistrano-passenger
@@ -271,6 +277,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  ruby-oci8
   simplecov (~> 0.17.1)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,8 @@ GEM
     activerecord (6.0.3.1)
       activemodel (= 6.0.3.1)
       activesupport (= 6.0.3.1)
+    activerecord-import (1.0.5)
+      activerecord (>= 3.2)
     activerecord-oracle_enhanced-adapter (6.0.2)
       activerecord (~> 6.0.0)
       ruby-plsql (>= 0.6.0)
@@ -256,6 +258,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-import
   activerecord-oracle_enhanced-adapter
   bootsnap
   byebug

--- a/README.md
+++ b/README.md
@@ -64,3 +64,8 @@ Note that CI is configured to automatically update the image hosted on DockerHub
 
     $ docker build -t suldlss/suri-rails:latest .
     $ docker push suldlss/suri-rails:latest
+
+## Migrate
+```
+RAILS_ENV=production bin/export-legacy-data <user> <password> <database> > identifiers.csv
+```

--- a/bin/export-legacy-data
+++ b/bin/export-legacy-data
@@ -6,7 +6,7 @@
 # before running: gem install ruby-oci8
 #
 # Usage:
-#   ruby export-legacy-data <user> <password> <database> > identifiers.csv
+#   export-legacy-data <user> <password> <database> > identifiers.csv
 
 require 'ruby-oci8'
 require 'csv'

--- a/bin/export-legacy-data
+++ b/bin/export-legacy-data
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# This script extracts the data from the legacy oracle database and writes it to CSV.
+#
+# before running: gem install ruby-oci8
+#
+# Usage:
+#   ruby export-legacy-data <user> <password> <database> > identifiers.csv
+
+require 'ruby-oci8'
+require 'csv'
+
+conn = OCI8.new(ARGV[0], ARGV[1], ARGV[2])
+columns = %w[identifier created_by created]
+sql = <<~SQL
+  SELECT #{columns.join(', ')} FROM identifier
+SQL
+CSV do |csv_out|
+  csv_out << columns
+  conn.exec(sql) do |r|
+    csv_out << r
+  end
+end

--- a/bin/import-legacy-data
+++ b/bin/import-legacy-data
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# This script imports the CSV data that was extracted from the legacy Oracle database.
+#
+# Usage:
+#   ./bin/import-legacy-workflow <pathToCSV>
+
+puts 'Loading environment...'
+require File.expand_path('../config/environment', __dir__)
+
+require 'csv'
+
+CSV.open(ARGV[0], headers: :first_row).each_slice(10_000) do |batch|
+  values = batch.map do |line|
+    legacy = line.to_h
+
+    # Renamed field
+    created_at = legacy.delete('created')
+
+    # We must provide updated_at, or it will display as the import time in the lifecycle.
+    legacy.merge(created_at: created_at, updated_at: created_at)
+  end
+  Identifier.import(values.compact)
+end


### PR DESCRIPTION
## Why was this change made?

So we can connect to the oracle database to migrate the data

## How was this change tested?
n/a


## Which documentation and/or configurations were updated?


n/a
