### PR TITLE
Remove the index method

### DIFF
--- a/app/controllers/identifiers_controller.rb
+++ b/app/controllers/identifiers_controller.rb
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
 
 class IdentifiersController < ApplicationController
-  # GET /identifiers
-  def index
-    @identifiers = Identifier.all
-
-    render json: @identifiers
-  end
-
   # GET /identifiers/1
   def show
     @identifier = Identifier.find_by!(identifier: params[:id])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  resources :identifiers, only: %i[index show create]
+  resources :identifiers, only: %i[show create]
 
   # legacy routes
   post '/suri2/namespaces/druid/identifiers' => 'identifiers#create'

--- a/spec/requests/identifiers_spec.rb
+++ b/spec/requests/identifiers_spec.rb
@@ -5,14 +5,6 @@ require 'rails_helper'
 RSpec.describe 'Identifiers', type: :request do
   let!(:identifier) { Identifier.mint }
 
-  describe 'GET #index' do
-    it 'returns a success response' do
-      get '/identifiers'
-      expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to include hash_including('identifier' => identifier.identifier)
-    end
-  end
-
   describe 'GET #show' do
     context 'when identifier is minted' do
       it 'returns a success response' do

--- a/spec/routing/identifiers_routing_spec.rb
+++ b/spec/routing/identifiers_routing_spec.rb
@@ -4,10 +4,6 @@ require 'rails_helper'
 
 RSpec.describe IdentifiersController, type: :routing do
   describe 'routing' do
-    it 'routes to #index' do
-      expect(get: '/identifiers').to route_to('identifiers#index')
-    end
-
     it 'routes to #show' do
       expect(get: '/identifiers/1').to route_to('identifiers#show', id: '1')
     end


### PR DESCRIPTION


## Why was this change made?

This is a simple way to exhaust the system resources and is vulnerable to a DOS attack.  I don't believe it is used anywhere

## How was this change tested?

test suite

## Which documentation and/or configurations were updated?

n/a

