### PR TITLE
Add the tmp/pids directory to the repo for docker builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@
 !/log/.keep
 !/tmp/.keep
 
+# Ignore pidfiles, but keep the directory.
+/tmp/pids/*
+!/tmp/pids/
+!/tmp/pids/.keep
+
 /node_modules
 /yarn-error.log
 


### PR DESCRIPTION
## Why was this change made?
Otherwise the docker container fails with:
```
/usr/local/bundle/gems/puma-4.3.7/lib/puma/launcher.rb:216:in `initialize': No such file or directory @ rb_sysopen - tmp/pids/server.pid (Errno::ENOENT)
```


## How was this change tested?



## Which documentation and/or configurations were updated?



