### PR TITLE
upgrade circleci build for ruby 3.0.3; upgrade listen gem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 parameters:
   ruby-version:
     type: string
-    default: "2.7.1"
+    default: "3.0.3"
 executors:
   docker-publisher:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
     environment:
       IMAGE_NAME: suldlss/suri-rails
     docker:
-    - image: circleci/buildpack-deps:stretch
+    - image: cimg/buildpack-deps:stretch
 jobs:
   test:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,10 @@
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
 version: 2.1
+parameters:
+  ruby-version:
+    type: string
+    default: "2.7.1"
 executors:
   docker-publisher:
     environment:
@@ -12,8 +16,7 @@ executors:
 jobs:
   test:
     docker:
-      # specify the version you desire here
-      - image: circleci/ruby:2.7.1-node
+      - image: 'cimg/ruby:<< pipeline.parameters.ruby-version >>-node'
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3
@@ -49,7 +52,7 @@ jobs:
 
       - run:
           name: Install/Upgrade bundler
-          command: gem install bundler -v 2.1.4
+          command: gem install bundler -v 2.3.4
 
       - run:
           name: Which bundler?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,15 @@ parameters:
   ruby-version:
     type: string
     default: "3.0.3"
+  postgres-version:
+    type: string
+    default: "11.13"
 executors:
   docker-publisher:
     environment:
       IMAGE_NAME: suldlss/suri-rails
     docker:
-    - image: cimg/buildpack-deps:stretch
+    - image: cimg/base
 jobs:
   test:
     docker:
@@ -26,7 +29,7 @@ jobs:
           PGPASSWORD: sekret
           RAILS_ENV: test
           NOKOGIRI_USE_SYSTEM_LIBRARIES: true
-      - image: circleci/postgres:11
+      - image: 'cimg/postgres:<< pipeline.parameters.postgres-version >>'
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: suri

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ end
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
-  gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'listen', '~> 3.7'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,10 +114,9 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.6.1)
     json_schema (0.21.0)
-    listen (3.1.5)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-      ruby_dep (~> 1.2)
+    listen (3.7.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -229,7 +228,6 @@ GEM
     rubocop-rspec (2.6.0)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
-    ruby_dep (1.5.0)
     simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -265,7 +263,7 @@ DEPENDENCIES
   committee
   dlss-capistrano
   honeybadger
-  listen (>= 3.0.5, < 3.2)
+  listen (~> 3.7)
   okcomputer
   pg
   puma (~> 5.5)
@@ -282,4 +280,4 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
 
 BUNDLED WITH
-   2.2.27
+   2.2.32


### PR DESCRIPTION
## Why was this change made?

- Migrating to ruby 3.0.3
- Stop using deprecated circleci images
- Move a smidgen towards using our to-be-written infrastructure ruby-rails orb

## How was this change tested?

circleci and deployed to qa and stage VMs

## Which documentation and/or configurations were updated?



