### PR TITLE
Gemfile: simplecov no longer needs version restriction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :development, :test do
   gem 'rubocop-performance'
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
-  gem 'simplecov', '~> 0.17.1' # 0.18 breaks reporting https://github.com/codeclimate/test-reporter/issues/418
+  gem 'simplecov'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,6 @@ GEM
     honeybadger (4.9.0)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
-    json (2.6.1)
     json_schema (0.21.0)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -228,11 +227,12 @@ GEM
     rubocop-rspec (2.6.0)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
-    simplecov (0.17.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.3)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -275,7 +275,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
-  simplecov (~> 0.17.1)
+  simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
 


### PR DESCRIPTION
## Why was this change made?

simpler Gemfile, easier maintenance

## How was this change tested?



## Which documentation and/or configurations were updated?



