### PR TITLE
circleci: fix docker image used for building docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
     environment:
       IMAGE_NAME: suldlss/suri-rails
     docker:
-    - image: cimg/base
+    - image: cimg/base:stable
 jobs:
   test:
     docker:


### PR DESCRIPTION
## Why was this change made?

I *think* this will work;  see https://github.com/sul-dlss/dlme/pull/1382/files

## How was this change tested?



## Which documentation and/or configurations were updated?



