### PR TITLE
Update Dockerfile base image to ruby 3.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2-alpine
+FROM ruby:3.0.3-alpine
 
 LABEL maintainer="Stanford Libraries Infrastructure Team <dlss-infrastructure-team@lists.stanford.edu>"
 


### PR DESCRIPTION
## Why was this change made?

Dockerfile base image ruby version in sync with app (ruby 3.0.3)

## How was this change tested?

Docker image builds


## Which documentation and/or configurations were updated?



