### PR TITLE
Disentangle development and test databases

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -11,12 +11,14 @@ default: &default
 
 development:
   <<: *default
+  database: "<%= ENV.fetch('DATABASE_NAME', 'suri_development') %>"
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
+  database: "<%= ENV.fetch('DATABASE_NAME', 'suri_test') %>"
 
 production:
   <<: *default


### PR DESCRIPTION
## Why was this change made? 🤔

suri-rails is an outlier among our applications in that it re-uses the same DB across environments, a Rails anti-pattern. Now Rails should complain at us less. This commit only affects CI and local development, not deployed instances.


## How was this change tested? 🤨

CI
