### PR TITLE
Add `config.hosts` value for containerland

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,6 +5,11 @@ require 'active_support/core_ext/integer/time'
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Added in Rails 6. Allows the app when RAILS_ENV=development to be contacted
+  # with a Host header other than `localhost`, `0.0.0.0`, or `::`. We need this in
+  # containerland, else e.g. DSA cannot reach Suri.
+  config.hosts << ENV.fetch('ALLOWED_DEV_HOSTNAME', 'suri')
+  
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.


### PR DESCRIPTION
Removed in the Rails 7.2 bump: https://github.com/sul-dlss/suri-rails/pull/365/files#diff-d3c4b3f41072daa416f1920511e9b2e26caea8c5cec0a14cb9508589a4dafa47L8-L11

Now causing CI failures.
