### PR TITLE
Remove spring and listen dependencies in dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,14 +27,6 @@ group :development, :test do
   gem 'simplecov'
 end
 
-group :development do
-  # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
-  gem 'listen', '~> 3.7'
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
-end
-
 group :deployment do
   gem 'capistrano-passenger', require: false
   gem 'capistrano-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,9 +126,6 @@ GEM
     drb (2.2.1)
     ed25519 (1.3.0)
     erubi (1.13.1)
-    ffi (1.17.1)
-    ffi (1.17.1-x86_64-darwin)
-    ffi (1.17.1-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
     honeybadger (5.26.2)
@@ -144,9 +141,6 @@ GEM
     json (2.9.1)
     json_schema (0.21.0)
     language_server-protocol (3.17.0.3)
-    listen (3.9.0)
-      rb-fsevent (~> 0.10, >= 0.10.3)
-      rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.6.5)
     loofah (2.24.0)
       crass (~> 1.0.2)
@@ -239,9 +233,6 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
-    rb-fsevent (0.11.2)
-    rb-inotify (0.11.1)
-      ffi (~> 1.0)
     rdoc (6.11.0)
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
@@ -307,10 +298,6 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
-    spring (2.1.1)
-    spring-watcher-listen (2.0.1)
-      listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
     sshkit (1.23.2)
       base64
       net-scp (>= 1.1.2)
@@ -345,7 +332,6 @@ DEPENDENCIES
   committee
   dlss-capistrano
   honeybadger
-  listen (~> 3.7)
   okcomputer
   pg
   puma
@@ -361,8 +347,6 @@ DEPENDENCIES
   rubocop-rspec
   rubocop-rspec_rails
   simplecov
-  spring
-  spring-watcher-listen (~> 2.0.0)
 
 BUNDLED WITH
    2.4.13


### PR DESCRIPTION
# Why was this change made?

Why? 1. They are outdated and 2. We do not use them

# How was this change tested?

CI, stage
