### PR TITLE
Remove explicit one-time key setup

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -2,6 +2,5 @@
 
 server 'sul-suri-prod.stanford.edu', user: 'suri', roles: %w[web app db]
 
-Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'
 set :bundle_without, %w[deployment test development].join(' ')

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -2,6 +2,5 @@
 
 server 'sul-suri-qa.stanford.edu', user: 'suri', roles: %w[web app db]
 
-Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'
 set :bundle_without, %w[deployment test development].join(' ')

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -2,6 +2,5 @@
 
 server 'sul-suri-stage.stanford.edu', user: 'suri', roles: %w[web app db]
 
-Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'
 set :bundle_without, %w[deployment test development].join(' ')


### PR DESCRIPTION
This line has been a no-op since dlss-capistrano 5.2.0. Setting up the one-time key is done automatically in dlss-capistrano now.