### PR TITLE
Update ruby-rails orb to 4.9.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby-rails: sul-dlss/ruby-rails@4.8.0
+  ruby-rails: sul-dlss/ruby-rails@4.9.0
 workflows:
   build:
     jobs:


### PR DESCRIPTION
## Why was this change made? 🤔
To build docker images for amd64 and arm64.


## How was this change tested? 🤨

⚡ ⚠ If this change involves changing the [suri-rails API](https://github.com/sul-dlss/suri-rails/blob/main/openapi.yml), ***run [an integration test](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


